### PR TITLE
make ssh key configurable

### DIFF
--- a/instances.tf
+++ b/instances.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "re" {
   subnet_id              = "${element(var.vpc-subnets, count.index)}"
   vpc_security_group_ids = [aws_security_group.re.id]
   source_dest_check      = false
-  key_name               = "${var.vpc-name}"
+  key_name               = local.ssh_key
   tags                   = merge({ Name = "RedisEnterprise-${var.vpc-name}-${count.index}" }, var.common-tags)
 
 }

--- a/main.tf
+++ b/main.tf
@@ -7,3 +7,12 @@ provider "aws" {
 locals {
   count_flash = (var.enable-flash == true ? var.data-node-count : 0)
 }
+
+locals {
+  ssh_key_path = (var.ssh-key == "" ? "~/.ssh/${var.vpc-name}.pem" : "~/.ssh/${replace(var.ssh-key, ".pem", "")}.pem")
+}
+
+
+locals {
+  ssh_key= (var.ssh-key == "" ? var.vpc-name : replace(var.ssh-key, ".pem", ""))
+}

--- a/provisioning.tf
+++ b/provisioning.tf
@@ -6,7 +6,7 @@ resource "null_resource" "remote-config" {
     connection {
       user        = "ubuntu"
       host        = "${element(aws_eip.re-eip.*.public_ip, count.index)}"
-      private_key = "${file("~/.ssh/${var.vpc-name}.pem")}"
+      private_key = "${file(local.ssh_key_path)}"
       agent       = true
     }
     inline = ["sudo apt update > /dev/null  && sudo apt install -y python python-pip > /dev/null"]
@@ -57,7 +57,7 @@ resource "null_resource" "ssh-setup" {
 resource "null_resource" "ansible-run" {
   count = var.data-node-count
   provisioner "local-exec" {
-    command = "ansible-playbook ${path.module}/ansible/playbook.yml --private-key ~/.ssh/${var.vpc-name}.pem -i /tmp/${var.vpc-name}_node_${count.index}.ini --become -e 'MYENV=1'"
+    command = "ansible-playbook ${path.module}/ansible/playbook.yml --private-key ${local.ssh_key_path} -i /tmp/${var.vpc-name}_node_${count.index}.ini --become -e 'MYENV=1'"
   }
   depends_on = ["null_resource.remote-config"]
 }

--- a/test/main.tf
+++ b/test/main.tf
@@ -4,18 +4,19 @@ provider "aws" {
 }
 
 module "mymodule" {
-  source   = "../"
-  profile  = "redislabs"
-  region   = "us-east-1"
-  open-nets = ["192.168.0.127/32"]
+  source          = "../"
+  profile         = "redislabs"
+  region          = "us-east-1"
+  open-nets       = ["192.168.0.127/32"]
   data-node-count = 3
-  vpc-cidr = "10.0.0.0/16"
-  vpc-subnets = ["subnet-1", "subnet-2"]
-  vpc-id = "vpc-12345678"
-  vpc-name = "myvpc"
-  vpc-azs = ["us-west-1a", "us-west-1b"]
-  common-tags = {
-    "Owner"   = "maguec"
-    "Project" = "example"
+  vpc-cidr        = "10.0.0.0/16"
+  vpc-subnets     = ["subnet-1", "subnet-2"]
+  vpc-id          = "vpc-12345678"
+  vpc-name        = "myvpc"
+  ssh-key         = "test.pem"
+  vpc-azs         = ["us-west-1a", "us-west-1b"]
+  common-tags     = {
+    "Owner"       = "maguec"
+    "Project"     = "example"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,12 @@ variable "vpc-name" {
   description = "The Name of the VPC"
 }
 
+variable "ssh-key" {
+  description = "Set if the SSH key you wish to use does not match the VPC name"
+  default = ""
+}
+
+
 variable "vpc-subnets" {
   type        = list
   description = "The list of subnets available to the VPC"


### PR DESCRIPTION
Fixes issue 

It's not possible to set the ssh-key var and it will attempt to use that key instead of the vpc-name key

https://github.com/Redislabs-Solution-Architects/tfmodule-aws-redis-enterprise/issues/1